### PR TITLE
Update dependencies for build, firebase, and revision data deploy packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "repository": "https://github.com/ibroadfo/ember-cli-deploy-firebase-pack",
   "scripts": {},
   "dependencies": {
-    "ember-cli-deploy-build": "1.0.0",
-    "ember-cli-deploy-firebase": "0.2.8",
-    "ember-cli-deploy-revision-data": "1.0.0"
+    "ember-cli-deploy-build": "^1.0.0",
+    "ember-cli-deploy-firebase": "~0.2.0",
+    "ember-cli-deploy-revision-data": "^1.0.0"
   },
   "devDependencies": {
     "ember-cli": "2.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-firebase-pack",
-  "version": "0.3.2",
+  "version": "0.3.1",
   "description": "An ember-cli-deploy plugin pack implementing a simple firebase hosting deploy pattern.",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-firebase-pack",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "An ember-cli-deploy plugin pack implementing a simple firebase hosting deploy pattern.",
   "keywords": [
     "ember-addon",
@@ -12,9 +12,9 @@
   "repository": "https://github.com/ibroadfo/ember-cli-deploy-firebase-pack",
   "scripts": {},
   "dependencies": {
-    "ember-cli-deploy-build": "^0.1.1",
-    "ember-cli-deploy-firebase": "~0.2.0",
-    "ember-cli-deploy-revision-data": "^0.3.2"
+    "ember-cli-deploy-build": "1.0.0",
+    "ember-cli-deploy-firebase": "0.2.8",
+    "ember-cli-deploy-revision-data": "1.0.0"
   },
   "devDependencies": {
     "ember-cli": "2.12.1",


### PR DESCRIPTION
Also bump version to 0.3.2. This should get rid of the deprecation errors.